### PR TITLE
Predicates & Accessible elements

### DIFF
--- a/Shelley.xcodeproj/project.pbxproj
+++ b/Shelley.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		06788FF417CF17F000541459 /* SYPredicateFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 06788FF117CF17F000541459 /* SYPredicateFilter.h */; };
 		06788FF517CF17F000541459 /* SYPredicateFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 06788FF217CF17F000541459 /* SYPredicateFilter.m */; };
 		06788FF617CF17F000541459 /* SYPredicateFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 06788FF217CF17F000541459 /* SYPredicateFilter.m */; };
+		06788FF917CF38DB00541459 /* SYUIAElementFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 06788FF717CF38D900541459 /* SYUIAElementFilter.h */; };
+		06788FFA17CF38DB00541459 /* SYUIAElementFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 06788FF817CF38DA00541459 /* SYUIAElementFilter.m */; };
 		3009124B16A599960023CC56 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3009124A16A599960023CC56 /* SenTestingKit.framework */; };
 		30313F7B16AB171E00DC6D3F /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 30313F7A16AB171E00DC6D3F /* Cocoa.framework */; };
 		30313F7D16ABB3E300DC6D3F /* ShelleyMac-Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = 30313F7C16ABB3E300DC6D3F /* ShelleyMac-Prefix.pch */; };
@@ -93,11 +95,13 @@
 /* Begin PBXFileReference section */
 		06788FF117CF17F000541459 /* SYPredicateFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SYPredicateFilter.h; sourceTree = "<group>"; };
 		06788FF217CF17F000541459 /* SYPredicateFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SYPredicateFilter.m; sourceTree = "<group>"; };
+		06788FF717CF38D900541459 /* SYUIAElementFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SYUIAElementFilter.h; sourceTree = "<group>"; };
+		06788FF817CF38DA00541459 /* SYUIAElementFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SYUIAElementFilter.m; sourceTree = "<group>"; };
 		3009123716A599960023CC56 /* libShelleyMac.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libShelleyMac.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		3009123B16A599960023CC56 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
 		3009123C16A599960023CC56 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		3009123D16A599960023CC56 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
-		3009124916A599960023CC56 /* ShellyMacTests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = ShellyMacTests.octest; path = ShelleyMacTests.octest; sourceTree = BUILT_PRODUCTS_DIR; };
+		3009124916A599960023CC56 /* ShelleyMacTests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ShelleyMacTests.octest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3009124A16A599960023CC56 /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
 		30313F7816AB109B00DC6D3F /* ShelleyMacTests-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ShelleyMacTests-Prefix.pch"; sourceTree = "<group>"; };
 		30313F7A16AB171E00DC6D3F /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
@@ -249,7 +253,7 @@
 				D6E8FF3213D3DC9200D24F43 /* libShelley.a */,
 				D6CF39AC13D3E481000C7901 /* Unit Tests.octest */,
 				3009123716A599960023CC56 /* libShelleyMac.a */,
-				3009124916A599960023CC56 /* ShellyMacTests.octest */,
+				3009124916A599960023CC56 /* ShelleyMacTests.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -337,6 +341,8 @@
 				06788FF217CF17F000541459 /* SYPredicateFilter.m */,
 				F85939C2173452100074CB9E /* SYSelectorFilter.h */,
 				F85939C3173452100074CB9E /* SYSelectorFilter.m */,
+				06788FF717CF38D900541459 /* SYUIAElementFilter.h */,
+				06788FF817CF38DA00541459 /* SYUIAElementFilter.m */,
 			);
 			path = Filters;
 			sourceTree = "<group>";
@@ -380,6 +386,7 @@
 				F85939F6173452110074CB9E /* SYFrankSelectorEngine.h in Headers */,
 				F85939FC173452110074CB9E /* SYParser.h in Headers */,
 				06788FF317CF17F000541459 /* SYPredicateFilter.h in Headers */,
+				06788FF917CF38DB00541459 /* SYUIAElementFilter.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -419,7 +426,7 @@
 			);
 			name = ShelleyMacTests;
 			productName = ShellyMacTests;
-			productReference = 3009124916A599960023CC56 /* ShellyMacTests.octest */;
+			productReference = 3009124916A599960023CC56 /* ShelleyMacTests.octest */;
 			productType = "com.apple.product-type.bundle";
 		};
 		D6CF39AB13D3E481000C7901 /* Unit Tests */ = {
@@ -607,6 +614,7 @@
 				F85939F8173452110074CB9E /* SYFrankSelectorEngine.m in Sources */,
 				F85939FE173452110074CB9E /* SYParser.m in Sources */,
 				06788FF517CF17F000541459 /* SYPredicateFilter.m in Sources */,
+				06788FFA17CF38DB00541459 /* SYUIAElementFilter.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Shelley.xcodeproj/project.pbxproj
+++ b/Shelley.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		06788FF317CF17F000541459 /* SYPredicateFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 06788FF117CF17F000541459 /* SYPredicateFilter.h */; };
+		06788FF417CF17F000541459 /* SYPredicateFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 06788FF117CF17F000541459 /* SYPredicateFilter.h */; };
+		06788FF517CF17F000541459 /* SYPredicateFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 06788FF217CF17F000541459 /* SYPredicateFilter.m */; };
+		06788FF617CF17F000541459 /* SYPredicateFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = 06788FF217CF17F000541459 /* SYPredicateFilter.m */; };
 		3009124B16A599960023CC56 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3009124A16A599960023CC56 /* SenTestingKit.framework */; };
 		30313F7B16AB171E00DC6D3F /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 30313F7A16AB171E00DC6D3F /* Cocoa.framework */; };
 		30313F7D16ABB3E300DC6D3F /* ShelleyMac-Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = 30313F7C16ABB3E300DC6D3F /* ShelleyMac-Prefix.pch */; };
@@ -87,6 +91,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		06788FF117CF17F000541459 /* SYPredicateFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SYPredicateFilter.h; sourceTree = "<group>"; };
+		06788FF217CF17F000541459 /* SYPredicateFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SYPredicateFilter.m; sourceTree = "<group>"; };
 		3009123716A599960023CC56 /* libShelleyMac.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libShelleyMac.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		3009123B16A599960023CC56 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
 		3009123C16A599960023CC56 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
@@ -327,6 +333,8 @@
 				F85939BF173452100074CB9E /* SYNthElementFilter.m */,
 				F85939C0173452100074CB9E /* SYParents.h */,
 				F85939C1173452100074CB9E /* SYParents.m */,
+				06788FF117CF17F000541459 /* SYPredicateFilter.h */,
+				06788FF217CF17F000541459 /* SYPredicateFilter.m */,
 				F85939C2173452100074CB9E /* SYSelectorFilter.h */,
 				F85939C3173452100074CB9E /* SYSelectorFilter.m */,
 			);
@@ -351,6 +359,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F85939F7173452110074CB9E /* SYFrankSelectorEngine.h in Headers */,
+				06788FF417CF17F000541459 /* SYPredicateFilter.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -370,6 +379,7 @@
 				F85939F0173452110074CB9E /* Shelley.h in Headers */,
 				F85939F6173452110074CB9E /* SYFrankSelectorEngine.h in Headers */,
 				F85939FC173452110074CB9E /* SYParser.h in Headers */,
+				06788FF317CF17F000541459 /* SYPredicateFilter.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -537,6 +547,7 @@
 				F85939F4173452110074CB9E /* Shelley.m in Sources */,
 				F85939FA173452110074CB9E /* SYFrankSelectorEngine.m in Sources */,
 				F8593A00173452110074CB9E /* SYParser.m in Sources */,
+				06788FF617CF17F000541459 /* SYPredicateFilter.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -595,6 +606,7 @@
 				F85939F2173452110074CB9E /* Shelley.m in Sources */,
 				F85939F8173452110074CB9E /* SYFrankSelectorEngine.m in Sources */,
 				F85939FE173452110074CB9E /* SYParser.m in Sources */,
+				06788FF517CF17F000541459 /* SYPredicateFilter.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Shelley.xcodeproj/project.pbxproj
+++ b/Shelley.xcodeproj/project.pbxproj
@@ -15,13 +15,13 @@
 		3089D99716A8E4B40049CD1D /* SYParserTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D68761F613D4092A0057A375 /* SYParserTests.m */; };
 		3089D99816A8E4B40049CD1D /* SYParentsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D610CA6113D9F8D8008AB1F5 /* SYParentsTests.m */; };
 		3089D99916A8E4B40049CD1D /* SenTestCase+Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = D610CA6413D9F9E7008AB1F5 /* SenTestCase+Extensions.m */; };
-		3089D99A16A8E4B40049CD1D /* SYPredicateFilterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D610CA6713DA0752008AB1F5 /* SYPredicateFilterTests.m */; };
+		3089D99A16A8E4B40049CD1D /* SYSelectorFilterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D610CA6713DA0752008AB1F5 /* SYSelectorFilterTests.m */; };
 		3089D9A316A8E4DA0049CD1D /* NSObject+ShelleyExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 306097C016A6F4D40032EC9F /* NSObject+ShelleyExtensions.m */; };
 		30AAE66616A8E206004A7D8A /* NSViewWithAccessibilityLabel.m in Sources */ = {isa = PBXBuildFile; fileRef = 30AAE66516A8E206004A7D8A /* NSViewWithAccessibilityLabel.m */; };
 		4D77E71915188374000D0EEE /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D77E71815188374000D0EEE /* QuartzCore.framework */; };
 		D610CA6213D9F8D8008AB1F5 /* SYParentsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D610CA6113D9F8D8008AB1F5 /* SYParentsTests.m */; };
 		D610CA6513D9F9E7008AB1F5 /* SenTestCase+Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = D610CA6413D9F9E7008AB1F5 /* SenTestCase+Extensions.m */; };
-		D610CA6813DA0752008AB1F5 /* SYPredicateFilterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D610CA6713DA0752008AB1F5 /* SYPredicateFilterTests.m */; };
+		D610CA6813DA0752008AB1F5 /* SYSelectorFilterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D610CA6713DA0752008AB1F5 /* SYSelectorFilterTests.m */; };
 		D610CA6C13DA15A4008AB1F5 /* UIView+ShelleyExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = D610CA6A13DA15A3008AB1F5 /* UIView+ShelleyExtensions.m */; };
 		D610CA6D13DA15A4008AB1F5 /* UIView+ShelleyExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = D610CA6A13DA15A3008AB1F5 /* UIView+ShelleyExtensions.m */; };
 		D648FB3913E5EA7E003FBE5A /* UIViewWithAccessibilityLabel.m in Sources */ = {isa = PBXBuildFile; fileRef = D648FB3813E5EA7E003FBE5A /* UIViewWithAccessibilityLabel.m */; };
@@ -53,11 +53,11 @@
 		F85939E3173452100074CB9E /* SYParents.m in Sources */ = {isa = PBXBuildFile; fileRef = F85939C1173452100074CB9E /* SYParents.m */; };
 		F85939E4173452100074CB9E /* SYParents.m in Sources */ = {isa = PBXBuildFile; fileRef = F85939C1173452100074CB9E /* SYParents.m */; };
 		F85939E5173452100074CB9E /* SYParents.m in Sources */ = {isa = PBXBuildFile; fileRef = F85939C1173452100074CB9E /* SYParents.m */; };
-		F85939E6173452110074CB9E /* SYPredicateFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = F85939C2173452100074CB9E /* SYPredicateFilter.h */; };
-		F85939E8173452110074CB9E /* SYPredicateFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = F85939C3173452100074CB9E /* SYPredicateFilter.m */; };
-		F85939E9173452110074CB9E /* SYPredicateFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = F85939C3173452100074CB9E /* SYPredicateFilter.m */; };
-		F85939EA173452110074CB9E /* SYPredicateFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = F85939C3173452100074CB9E /* SYPredicateFilter.m */; };
-		F85939EB173452110074CB9E /* SYPredicateFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = F85939C3173452100074CB9E /* SYPredicateFilter.m */; };
+		F85939E6173452110074CB9E /* SYSelectorFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = F85939C2173452100074CB9E /* SYSelectorFilter.h */; };
+		F85939E8173452110074CB9E /* SYSelectorFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = F85939C3173452100074CB9E /* SYSelectorFilter.m */; };
+		F85939E9173452110074CB9E /* SYSelectorFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = F85939C3173452100074CB9E /* SYSelectorFilter.m */; };
+		F85939EA173452110074CB9E /* SYSelectorFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = F85939C3173452100074CB9E /* SYSelectorFilter.m */; };
+		F85939EB173452110074CB9E /* SYSelectorFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = F85939C3173452100074CB9E /* SYSelectorFilter.m */; };
 		F85939EC173452110074CB9E /* LoadableCategory.h in Headers */ = {isa = PBXBuildFile; fileRef = F85939C4173452100074CB9E /* LoadableCategory.h */; };
 		F85939EE173452110074CB9E /* SelectorEngineRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = F85939C5173452100074CB9E /* SelectorEngineRegistry.h */; };
 		F85939F0173452110074CB9E /* Shelley.h in Headers */ = {isa = PBXBuildFile; fileRef = F85939C6173452100074CB9E /* Shelley.h */; };
@@ -105,8 +105,8 @@
 		D610CA6113D9F8D8008AB1F5 /* SYParentsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SYParentsTests.m; sourceTree = "<group>"; };
 		D610CA6313D9F9E7008AB1F5 /* SenTestCase+Extensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SenTestCase+Extensions.h"; sourceTree = "<group>"; };
 		D610CA6413D9F9E7008AB1F5 /* SenTestCase+Extensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "SenTestCase+Extensions.m"; sourceTree = "<group>"; };
-		D610CA6613DA0752008AB1F5 /* SYPredicateFilterTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SYPredicateFilterTests.h; sourceTree = "<group>"; };
-		D610CA6713DA0752008AB1F5 /* SYPredicateFilterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SYPredicateFilterTests.m; sourceTree = "<group>"; };
+		D610CA6613DA0752008AB1F5 /* SYSelectorFilterTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SYSelectorFilterTests.h; sourceTree = "<group>"; };
+		D610CA6713DA0752008AB1F5 /* SYSelectorFilterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SYSelectorFilterTests.m; sourceTree = "<group>"; };
 		D610CA6A13DA15A3008AB1F5 /* UIView+ShelleyExtensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIView+ShelleyExtensions.m"; sourceTree = "<group>"; };
 		D648FB3713E5EA7E003FBE5A /* UIViewWithAccessibilityLabel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UIViewWithAccessibilityLabel.h; sourceTree = "<group>"; };
 		D648FB3813E5EA7E003FBE5A /* UIViewWithAccessibilityLabel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UIViewWithAccessibilityLabel.m; sourceTree = "<group>"; };
@@ -132,8 +132,8 @@
 		F85939BF173452100074CB9E /* SYNthElementFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SYNthElementFilter.m; sourceTree = "<group>"; };
 		F85939C0173452100074CB9E /* SYParents.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SYParents.h; sourceTree = "<group>"; };
 		F85939C1173452100074CB9E /* SYParents.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SYParents.m; sourceTree = "<group>"; };
-		F85939C2173452100074CB9E /* SYPredicateFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SYPredicateFilter.h; sourceTree = "<group>"; };
-		F85939C3173452100074CB9E /* SYPredicateFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SYPredicateFilter.m; sourceTree = "<group>"; };
+		F85939C2173452100074CB9E /* SYSelectorFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SYSelectorFilter.h; sourceTree = "<group>"; };
+		F85939C3173452100074CB9E /* SYSelectorFilter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SYSelectorFilter.m; sourceTree = "<group>"; };
 		F85939C4173452100074CB9E /* LoadableCategory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LoadableCategory.h; sourceTree = "<group>"; };
 		F85939C5173452100074CB9E /* SelectorEngineRegistry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SelectorEngineRegistry.h; sourceTree = "<group>"; };
 		F85939C6173452100074CB9E /* Shelley.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Shelley.h; sourceTree = "<group>"; };
@@ -209,8 +209,8 @@
 				D610CA6113D9F8D8008AB1F5 /* SYParentsTests.m */,
 				D610CA6313D9F9E7008AB1F5 /* SenTestCase+Extensions.h */,
 				D610CA6413D9F9E7008AB1F5 /* SenTestCase+Extensions.m */,
-				D610CA6613DA0752008AB1F5 /* SYPredicateFilterTests.h */,
-				D610CA6713DA0752008AB1F5 /* SYPredicateFilterTests.m */,
+				D610CA6613DA0752008AB1F5 /* SYSelectorFilterTests.h */,
+				D610CA6713DA0752008AB1F5 /* SYSelectorFilterTests.m */,
 			);
 			path = "Unit Tests";
 			sourceTree = "<group>";
@@ -327,8 +327,8 @@
 				F85939BF173452100074CB9E /* SYNthElementFilter.m */,
 				F85939C0173452100074CB9E /* SYParents.h */,
 				F85939C1173452100074CB9E /* SYParents.m */,
-				F85939C2173452100074CB9E /* SYPredicateFilter.h */,
-				F85939C3173452100074CB9E /* SYPredicateFilter.m */,
+				F85939C2173452100074CB9E /* SYSelectorFilter.h */,
+				F85939C3173452100074CB9E /* SYSelectorFilter.m */,
 			);
 			path = Filters;
 			sourceTree = "<group>";
@@ -364,7 +364,7 @@
 				F85939D8173452100074CB9E /* SYFilter.h in Headers */,
 				F85939DA173452100074CB9E /* SYNthElementFilter.h in Headers */,
 				F85939E0173452100074CB9E /* SYParents.h in Headers */,
-				F85939E6173452110074CB9E /* SYPredicateFilter.h in Headers */,
+				F85939E6173452110074CB9E /* SYSelectorFilter.h in Headers */,
 				F85939EC173452110074CB9E /* LoadableCategory.h in Headers */,
 				F85939EE173452110074CB9E /* SelectorEngineRegistry.h in Headers */,
 				F85939F0173452110074CB9E /* Shelley.h in Headers */,
@@ -533,7 +533,7 @@
 				F85939D6173452100074CB9E /* SYClassFilter.m in Sources */,
 				F85939DE173452100074CB9E /* SYNthElementFilter.m in Sources */,
 				F85939E4173452100074CB9E /* SYParents.m in Sources */,
-				F85939EA173452110074CB9E /* SYPredicateFilter.m in Sources */,
+				F85939EA173452110074CB9E /* SYSelectorFilter.m in Sources */,
 				F85939F4173452110074CB9E /* Shelley.m in Sources */,
 				F85939FA173452110074CB9E /* SYFrankSelectorEngine.m in Sources */,
 				F8593A00173452110074CB9E /* SYParser.m in Sources */,
@@ -549,13 +549,13 @@
 				3089D99716A8E4B40049CD1D /* SYParserTests.m in Sources */,
 				3089D99816A8E4B40049CD1D /* SYParentsTests.m in Sources */,
 				3089D99916A8E4B40049CD1D /* SenTestCase+Extensions.m in Sources */,
-				3089D99A16A8E4B40049CD1D /* SYPredicateFilterTests.m in Sources */,
+				3089D99A16A8E4B40049CD1D /* SYSelectorFilterTests.m in Sources */,
 				30AAE66616A8E206004A7D8A /* NSViewWithAccessibilityLabel.m in Sources */,
 				F85939D1173452100074CB9E /* SYArrayFilterTemplate.m in Sources */,
 				F85939D7173452100074CB9E /* SYClassFilter.m in Sources */,
 				F85939DF173452100074CB9E /* SYNthElementFilter.m in Sources */,
 				F85939E5173452100074CB9E /* SYParents.m in Sources */,
-				F85939EB173452110074CB9E /* SYPredicateFilter.m in Sources */,
+				F85939EB173452110074CB9E /* SYSelectorFilter.m in Sources */,
 				F85939F5173452110074CB9E /* Shelley.m in Sources */,
 				F8593A01173452110074CB9E /* SYParser.m in Sources */,
 			);
@@ -569,14 +569,14 @@
 				D68761F713D4092A0057A375 /* SYParserTests.m in Sources */,
 				D610CA6213D9F8D8008AB1F5 /* SYParentsTests.m in Sources */,
 				D610CA6513D9F9E7008AB1F5 /* SenTestCase+Extensions.m in Sources */,
-				D610CA6813DA0752008AB1F5 /* SYPredicateFilterTests.m in Sources */,
+				D610CA6813DA0752008AB1F5 /* SYSelectorFilterTests.m in Sources */,
 				D610CA6D13DA15A4008AB1F5 /* UIView+ShelleyExtensions.m in Sources */,
 				D648FB3913E5EA7E003FBE5A /* UIViewWithAccessibilityLabel.m in Sources */,
 				F85939CF173452100074CB9E /* SYArrayFilterTemplate.m in Sources */,
 				F85939D5173452100074CB9E /* SYClassFilter.m in Sources */,
 				F85939DD173452100074CB9E /* SYNthElementFilter.m in Sources */,
 				F85939E3173452100074CB9E /* SYParents.m in Sources */,
-				F85939E9173452110074CB9E /* SYPredicateFilter.m in Sources */,
+				F85939E9173452110074CB9E /* SYSelectorFilter.m in Sources */,
 				F85939F3173452110074CB9E /* Shelley.m in Sources */,
 				F85939FF173452110074CB9E /* SYParser.m in Sources */,
 			);
@@ -591,7 +591,7 @@
 				F85939D4173452100074CB9E /* SYClassFilter.m in Sources */,
 				F85939DC173452100074CB9E /* SYNthElementFilter.m in Sources */,
 				F85939E2173452100074CB9E /* SYParents.m in Sources */,
-				F85939E8173452110074CB9E /* SYPredicateFilter.m in Sources */,
+				F85939E8173452110074CB9E /* SYSelectorFilter.m in Sources */,
 				F85939F2173452110074CB9E /* Shelley.m in Sources */,
 				F85939F8173452110074CB9E /* SYFrankSelectorEngine.m in Sources */,
 				F85939FE173452110074CB9E /* SYParser.m in Sources */,

--- a/Source/Frank/SYFrankSelectorEngine.m
+++ b/Source/Frank/SYFrankSelectorEngine.m
@@ -31,9 +31,9 @@ static NSString *const registeredName = @"shelley_compat";
     Shelley *shelley = [Shelley withSelectorString:selector];
     
 #if TARGET_OS_IPHONE
-    return [shelley selectFromViews:[[UIApplication sharedApplication] windows]];
+    return [shelley selectFromViews:[NSArray arrayWithObject: [UIApplication sharedApplication]]];
 #else
-    return [shelley selectFromViews: [NSArray arrayWithObject: [NSApplication sharedApplication]]];
+    return [shelley selectFromViews:[NSArray arrayWithObject: [NSApplication sharedApplication]]];
 #endif
 }
 

--- a/Source/Shared/Filters/SYClassFilter.m
+++ b/Source/Shared/Filters/SYClassFilter.m
@@ -21,9 +21,17 @@
     NSMutableArray *descendants = [NSMutableArray array];
     
 #if TARGET_OS_IPHONE
-    for (ShelleyView *subview in [view subviews]) {
-        [descendants addObject:subview];
-        [descendants addObjectsFromArray:[self allDescendantsOf:subview]];
+    if ([view isKindOfClass:[UIApplication class]]) {
+        for (UIWindow *window in [(UIApplication* )view windows]) {
+            [descendants addObject:window];
+            [descendants addObjectsFromArray:[self allDescendantsOf:window]];
+        }        
+    }
+    else if ([view isKindOfClass:[UIView class]]) {
+        for (UIView *subview in [(UIView* )view subviews]) {
+            [descendants addObject:subview];
+            [descendants addObjectsFromArray:[self allDescendantsOf:subview]];
+        }
     }
 #else
     if ([view respondsToSelector: @selector(FEX_children)])
@@ -69,7 +77,6 @@
     [allViews addObjectsFromArray:[SYClassFilter allDescendantsOf:view]];
     return allViews;
 }
-
 
 -(NSArray *)applyToView:(ShelleyView *)view{
     NSArray *allViews = [self viewsToConsiderFromView:view];

--- a/Source/Shared/Filters/SYParents.m
+++ b/Source/Shared/Filters/SYParents.m
@@ -17,7 +17,11 @@
 #if TARGET_OS_IPHONE
     ShelleyView *currentView = view;
     
-    while(( currentView = [currentView superview] )){
+    if (![view isKindOfClass:[UIView class]]) {
+        return ancestors;
+    }
+    
+    while(( currentView = [(UIView*) currentView superview] )){
         [ancestors addObject:currentView];
     }
 #else

--- a/Source/Shared/Filters/SYPredicateFilter.h
+++ b/Source/Shared/Filters/SYPredicateFilter.h
@@ -1,0 +1,17 @@
+//
+//  SYPredicateFilter.h
+//  Shelley
+//
+//  Created by Ondrej Hanslik on 8/29/13.
+//  Copyright (c) 2013 ThoughtWorks. All rights reserved.
+//
+
+#import "SYFilter.h"
+
+@interface SYPredicateFilter : NSObject <SYFilter>
+
+@property (nonatomic, retain, readonly) NSPredicate *predicate;
+
+- (id)initWithPredicateString:(NSString *)predicateString;
+
+@end

--- a/Source/Shared/Filters/SYPredicateFilter.m
+++ b/Source/Shared/Filters/SYPredicateFilter.m
@@ -1,0 +1,73 @@
+//
+//  SYPredicateFilter.m
+//  Shelley
+//
+//  Created by Ondrej Hanslik on 8/29/13.
+//  Copyright (c) 2013 ThoughtWorks. All rights reserved.
+//
+
+#import "SYPredicateFilter.h"
+#import "Shelley.h"
+
+@interface SYPredicateFilter ()
+
+@property (nonatomic, retain, readwrite) NSPredicate* predicate;
+
+@end
+
+@implementation SYPredicateFilter
+
+@synthesize predicate = _predicate;
+
+#pragma mark - Life cycle
+
+- (id)initWithPredicateString:(NSString *)predicateString {
+    self = [super init];
+    
+    if (!self) {
+        return nil;
+    }
+
+    self.predicate = [NSPredicate predicateWithFormat:predicateString, nil];
+    
+    return self;
+}
+
+- (void)dealloc {
+    [_predicate release];
+    
+    [super dealloc];
+}
+
+#pragma mark - Filter implementation
+
+- (void)setDoNotDescend:(BOOL)doNotDescend {
+    //do nothing
+}
+
+- (BOOL)nextFilterShouldNotDescend {
+    return NO;
+}
+
+- (NSArray *)applyToViews:(NSArray *)views {
+    NSMutableArray* results = [NSMutableArray array];
+    
+    BOOL matchesPredicate;
+    
+    for (ShelleyView* view in views) {
+        @try {
+            matchesPredicate = [self.predicate evaluateWithObject:view];
+        }
+        @catch (NSException* e) {
+            matchesPredicate = NO;
+        }
+        
+        if (matchesPredicate) {
+            [results addObject:view];
+        }
+    }
+    
+    return results;
+}
+
+@end

--- a/Source/Shared/Filters/SYPredicateFilter.m
+++ b/Source/Shared/Filters/SYPredicateFilter.m
@@ -11,7 +11,7 @@
 
 @interface SYPredicateFilter ()
 
-@property (nonatomic, retain, readwrite) NSPredicate* predicate;
+@property (nonatomic, retain, readwrite) NSPredicate *predicate;
 
 @end
 
@@ -50,15 +50,15 @@
 }
 
 - (NSArray *)applyToViews:(NSArray *)views {
-    NSMutableArray* results = [NSMutableArray array];
+    NSMutableArray *results = [NSMutableArray array];
     
     BOOL matchesPredicate;
     
-    for (ShelleyView* view in views) {
+    for (ShelleyView *view in views) {
         @try {
             matchesPredicate = [self.predicate evaluateWithObject:view];
         }
-        @catch (NSException* e) {
+        @catch (NSException *e) {
             matchesPredicate = NO;
         }
         

--- a/Source/Shared/Filters/SYSelectorFilter.h
+++ b/Source/Shared/Filters/SYSelectorFilter.h
@@ -1,5 +1,5 @@
 //
-//  SYPredicateFilter.h
+//  SYSelectorFilter.h
 //  Shelley
 //
 //  Created by Pete Hodgson on 7/20/11.
@@ -8,7 +8,7 @@
 
 #import "SYArrayFilterTemplate.h"
 
-@interface SYPredicateFilter : SYArrayFilterTemplate {
+@interface SYSelectorFilter : SYArrayFilterTemplate {
     SEL _selector;
     NSArray *_args;
     

--- a/Source/Shared/Filters/SYSelectorFilter.h
+++ b/Source/Shared/Filters/SYSelectorFilter.h
@@ -13,6 +13,7 @@
     NSArray *_args;
     
 }
+
 @property (readonly) SEL selector;
 @property (readonly) NSArray *args;
 

--- a/Source/Shared/Filters/SYSelectorFilter.m
+++ b/Source/Shared/Filters/SYSelectorFilter.m
@@ -1,14 +1,14 @@
 //
-//  SYPredicateFilter.m
+//  SYSelectorFilter.m
 //  Shelley
 //
 //  Created by Pete Hodgson on 7/20/11.
 //  Copyright 2011 ThoughtWorks. All rights reserved.
 //
 
-#import "SYPredicateFilter.h"
+#import "SYSelectorFilter.h"
 
-@implementation SYPredicateFilter
+@implementation SYSelectorFilter
 @synthesize selector=_selector,args=_args;
 
 - (id)initWithSelector:(SEL)selector args:(NSArray *)args {

--- a/Source/Shared/Filters/SYUIAElementFilter.h
+++ b/Source/Shared/Filters/SYUIAElementFilter.h
@@ -1,0 +1,25 @@
+//
+//  SYUIAElementFilter.h
+//  Shelley
+//
+//  Created by Ondrej Hanslik on 8/29/13.
+//  Copyright (c) 2013 ThoughtWorks. All rights reserved.
+//
+
+#import "SYArrayFilterTemplate.h"
+
+#if TARGET_OS_IPHONE
+#define ACCESSIBILITY_TRAITS UIAccessibilityTraits
+#else
+#define ACCESSIBILITY_TRAITS NSUinteger
+#endif
+
+@interface SYUIAElementFilter : SYArrayFilterTemplate
+
+#if TARGET_OS_IPHONE
+@property (nonatomic, assign, readonly) ACCESSIBILITY_TRAITS traitsFilter;
+#endif
+
+- (id)initWithTraitsFilter:(NSString*)traitsString;
+
+@end

--- a/Source/Shared/Filters/SYUIAElementFilter.h
+++ b/Source/Shared/Filters/SYUIAElementFilter.h
@@ -8,17 +8,9 @@
 
 #import "SYArrayFilterTemplate.h"
 
-#if TARGET_OS_IPHONE
-#define ACCESSIBILITY_TRAITS UIAccessibilityTraits
-#else
-#define ACCESSIBILITY_TRAITS NSUinteger
-#endif
-
 @interface SYUIAElementFilter : SYArrayFilterTemplate
 
-#if TARGET_OS_IPHONE
-@property (nonatomic, assign, readonly) ACCESSIBILITY_TRAITS traitsFilter;
-#endif
+@property (nonatomic, assign, readonly) UIAccessibilityTraits traitsFilter;
 
 - (id)initWithTraitsFilter:(NSString *)traitsString;
 

--- a/Source/Shared/Filters/SYUIAElementFilter.h
+++ b/Source/Shared/Filters/SYUIAElementFilter.h
@@ -20,6 +20,6 @@
 @property (nonatomic, assign, readonly) ACCESSIBILITY_TRAITS traitsFilter;
 #endif
 
-- (id)initWithTraitsFilter:(NSString*)traitsString;
+- (id)initWithTraitsFilter:(NSString *)traitsString;
 
 @end

--- a/Source/Shared/Filters/SYUIAElementFilter.m
+++ b/Source/Shared/Filters/SYUIAElementFilter.m
@@ -10,7 +10,7 @@
 
 @interface SYUIAElementFilter ()
 
-@property (nonatomic, assign, readwrite) ACCESSIBILITY_TRAITS traitsFilter;
+@property (nonatomic, assign, readwrite) UIAccessibilityTraits traitsFilter;
 
 @end
 
@@ -20,7 +20,6 @@
 
 #pragma mark - Traits parsing
 
-#ifdef TARGET_OS_IPHONE
 + (UIAccessibilityTraits)traitFromString:(NSString *)traitString {
     traitString = [traitString stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
 
@@ -88,7 +87,6 @@
     
     return traitsFilter;
 }
-#endif
 
 #pragma mark - Life cycle
 
@@ -103,9 +101,7 @@
         return nil;
     }
     
-#ifdef TARGET_OS_IPHONE
     self.traitsFilter = [[self class] traitsFilterFromString:traitsString];
-#endif
     
     return self;
 }
@@ -119,7 +115,6 @@
 + (NSArray *)allDescendantsOf:(NSObject *)element{
     NSMutableArray *descendants = [NSMutableArray array];
     
-#if TARGET_OS_IPHONE
     if ([element isKindOfClass:[UIApplication class]]) {
         for (UIWindow *window in [(UIApplication *) element windows]) {
             [descendants addObject:window];
@@ -132,15 +127,6 @@
             [descendants addObjectsFromArray:[self allDescendantsOf:subview]];
         }
     }
-#else
-    if ([element respondsToSelector: @selector(FEX_children)]) {
-        for (id child in [element performSelector:@selector(FEX_children)]) {
-            [descendants addObject:child];
-            [descendants addObjectsFromArray:[self allDescendantsOf:child]];
-        }
-    }
-    
-#endif
 
     if (![element respondsToSelector:@selector(accessibilityElementCount)]) {
         return descendants;
@@ -175,7 +161,6 @@
 -(NSArray *)applyToView:(NSObject *)view{
     NSArray *elements = [self elementsToConsiderFromElement:view];
     
-#ifdef TARGET_OS_IPHONE
     if (self.traitsFilter == UIAccessibilityTraitNone) {
         return elements;
     }
@@ -193,9 +178,6 @@
     }
     
     return filteredElements;
-#else
-    return elements;
-#endif
 }
 
 @end

--- a/Source/Shared/Filters/SYUIAElementFilter.m
+++ b/Source/Shared/Filters/SYUIAElementFilter.m
@@ -1,0 +1,201 @@
+//
+//  SYUIAElementFilter.m
+//  Shelley
+//
+//  Created by Ondrej Hanslik on 8/29/13.
+//  Copyright (c) 2013 ThoughtWorks. All rights reserved.
+//
+
+#import "SYUIAElementFilter.h"
+
+@interface SYUIAElementFilter ()
+
+@property (nonatomic, assign, readwrite) ACCESSIBILITY_TRAITS traitsFilter;
+
+@end
+
+@implementation SYUIAElementFilter
+
+@synthesize traitsFilter = _traitsFilter;
+
+#pragma mark - Traits parsing
+
+#ifdef TARGET_OS_IPHONE
++ (UIAccessibilityTraits)traitFromString:(NSString*)traitString {
+    traitString = [traitString stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+
+    if ([traitString isEqualToString:@"button"]) {
+        return UIAccessibilityTraitButton;
+    }
+    else if ([traitString isEqualToString:@"link"]) {
+        return UIAccessibilityTraitLink;
+    }
+    else if ([traitString isEqualToString:@"header"]) {
+        return UIAccessibilityTraitHeader;
+    }
+    else if ([traitString isEqualToString:@"search-field"]) {
+        return UIAccessibilityTraitSearchField;
+    }
+    else if ([traitString isEqualToString:@"image"]) {
+        return UIAccessibilityTraitImage;
+    }
+    else if ([traitString isEqualToString:@"selected"]) {
+        return UIAccessibilityTraitSelected;
+    }
+    else if ([traitString isEqualToString:@"plays-sound"]) {
+        return UIAccessibilityTraitPlaysSound;
+    }
+    else if ([traitString isEqualToString:@"keyboard-key"]) {
+        return UIAccessibilityTraitKeyboardKey;
+    }
+    else if ([traitString isEqualToString:@"static-text"]) {
+        return UIAccessibilityTraitStaticText;
+    }
+    else if ([traitString isEqualToString:@"not-enabled"]) {
+        return UIAccessibilityTraitNotEnabled;
+    }
+    else if ([traitString isEqualToString:@"updates-frequently"]) {
+        return UIAccessibilityTraitUpdatesFrequently;
+    }
+    else if ([traitString isEqualToString:@"starts-media-session"]) {
+        return UIAccessibilityTraitStartsMediaSession;
+    }
+    else if ([traitString isEqualToString:@"adjustable"]) {
+        return UIAccessibilityTraitAdjustable;
+    }
+    else if ([traitString isEqualToString:@"allows-direct-interaction"]) {
+        return UIAccessibilityTraitAllowsDirectInteraction;
+    }
+    else if ([traitString isEqualToString:@"causes-page-turn"]) {
+        return UIAccessibilityTraitCausesPageTurn;
+    }
+    else {
+        [NSException raise:@"Invalid Accessibility Traits"
+                    format:@"Cannot parse accessibility traits \"%@\"", traitString];
+        
+        return nil;
+    }
+}
+
++ (UIAccessibilityTraits)traitsFilterFromString:(NSString*)traitsString {
+    NSArray* traitStrings = [traitsString componentsSeparatedByString:@","];
+    
+    UIAccessibilityTraits traitsFilter = UIAccessibilityTraitNone;
+    
+    for (NSString* traitString in traitStrings) {
+        traitsFilter |= [self traitFromString:traitString];
+    }
+    
+    return traitsFilter;
+}
+#endif
+
+#pragma mark - Life cycle
+
+- (id)init {
+    return [self initWithTraitsFilter:nil];
+}
+
+- (id)initWithTraitsFilter:(NSString*)traitsString {
+    self = [super init];
+    
+    if (!self) {
+        return nil;
+    }
+    
+#ifdef TARGET_OS_IPHONE
+    self.traitsFilter = [[self class] traitsFilterFromString:traitsString];
+#endif
+    
+    return self;
+}
+
+- (void)dealloc {
+    [super dealloc];
+}
+
+#pragma mark - Filter implementation
+
++ (NSArray *)allDescendantsOf:(NSObject *)element{
+    NSMutableArray *descendants = [NSMutableArray array];
+    
+#if TARGET_OS_IPHONE
+    if ([element isKindOfClass:[UIApplication class]]) {
+        for (UIWindow *window in [(UIApplication *) element windows]) {
+            [descendants addObject:window];
+            [descendants addObjectsFromArray:[self allDescendantsOf:window]];
+        }
+    }
+    else if ([element isKindOfClass:[UIView class]]) {
+        for (UIView *subview in [(UIView *) element subviews]) {
+            [descendants addObject:subview];
+            [descendants addObjectsFromArray:[self allDescendantsOf:subview]];
+        }
+    }
+#else
+    if ([element respondsToSelector: @selector(FEX_children)]) {
+        for (id child in [element performSelector:@selector(FEX_children)]) {
+            [descendants addObject:child];
+            [descendants addObjectsFromArray:[self allDescendantsOf:child]];
+        }
+    }
+    
+#endif
+
+    if (![element respondsToSelector:@selector(accessibilityElementCount)]) {
+        return descendants;
+    }
+
+    NSInteger elementCount = [(id) element accessibilityElementCount];
+    
+    if (elementCount <= 0 || elementCount == NSNotFound) {
+        return descendants;
+    }
+    
+    for (NSInteger i = 0; i < elementCount; i++) {
+        NSObject* subelement = [element accessibilityElementAtIndex:i];
+        
+        if (subelement != nil) {
+            [descendants addObject:subelement];
+        }
+    }
+
+    return descendants;
+}
+
+- (NSArray *)elementsToConsiderFromElement:(NSObject*)element {
+    NSMutableArray *elements = [NSMutableArray array];
+    
+    [elements addObject:element];
+    [elements addObjectsFromArray:[[self class] allDescendantsOf:element]];
+    
+    return elements;
+}
+
+-(NSArray *)applyToView:(NSObject *)view{
+    NSArray* elements = [self elementsToConsiderFromElement:view];
+    
+#ifdef TARGET_OS_IPHONE
+    if (self.traitsFilter == UIAccessibilityTraitNone) {
+        return elements;
+    }
+    
+    NSMutableArray* filteredElements = [NSMutableArray array];
+    
+    for (NSObject* element in elements) {
+        if ([element respondsToSelector:@selector(accessibilityTraits)]) {
+            UIAccessibilityTraits accessibilityTraits = [element accessibilityTraits];
+            
+            if ((accessibilityTraits & self.traitsFilter) == self.traitsFilter) {
+                [filteredElements addObject:element];
+            }
+        }
+    }
+    
+    return filteredElements;
+#else
+    return elements;
+#endif
+}
+
+@end

--- a/Source/Shared/Filters/SYUIAElementFilter.m
+++ b/Source/Shared/Filters/SYUIAElementFilter.m
@@ -21,7 +21,7 @@
 #pragma mark - Traits parsing
 
 #ifdef TARGET_OS_IPHONE
-+ (UIAccessibilityTraits)traitFromString:(NSString*)traitString {
++ (UIAccessibilityTraits)traitFromString:(NSString *)traitString {
     traitString = [traitString stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
 
     if ([traitString isEqualToString:@"button"]) {
@@ -77,12 +77,12 @@
     }
 }
 
-+ (UIAccessibilityTraits)traitsFilterFromString:(NSString*)traitsString {
-    NSArray* traitStrings = [traitsString componentsSeparatedByString:@","];
++ (UIAccessibilityTraits)traitsFilterFromString:(NSString *)traitsString {
+    NSArray *traitStrings = [traitsString componentsSeparatedByString:@","];
     
     UIAccessibilityTraits traitsFilter = UIAccessibilityTraitNone;
     
-    for (NSString* traitString in traitStrings) {
+    for (NSString *traitString in traitStrings) {
         traitsFilter |= [self traitFromString:traitString];
     }
     
@@ -153,7 +153,7 @@
     }
     
     for (NSInteger i = 0; i < elementCount; i++) {
-        NSObject* subelement = [element accessibilityElementAtIndex:i];
+        NSObject *subelement = [element accessibilityElementAtIndex:i];
         
         if (subelement != nil) {
             [descendants addObject:subelement];
@@ -163,7 +163,7 @@
     return descendants;
 }
 
-- (NSArray *)elementsToConsiderFromElement:(NSObject*)element {
+- (NSArray *)elementsToConsiderFromElement:(NSObject *)element {
     NSMutableArray *elements = [NSMutableArray array];
     
     [elements addObject:element];
@@ -173,7 +173,7 @@
 }
 
 -(NSArray *)applyToView:(NSObject *)view{
-    NSArray* elements = [self elementsToConsiderFromElement:view];
+    NSArray *elements = [self elementsToConsiderFromElement:view];
     
 #ifdef TARGET_OS_IPHONE
     if (self.traitsFilter == UIAccessibilityTraitNone) {
@@ -182,7 +182,7 @@
     
     NSMutableArray* filteredElements = [NSMutableArray array];
     
-    for (NSObject* element in elements) {
+    for (NSObject *element in elements) {
         if ([element respondsToSelector:@selector(accessibilityTraits)]) {
             UIAccessibilityTraits accessibilityTraits = [element accessibilityTraits];
             

--- a/Source/Shared/LoadableCategory.h
+++ b/Source/Shared/LoadableCategory.h
@@ -31,4 +31,4 @@
  *
  * @param UNIQUE_NAME A globally unique name.
  */
-#define MAKE_CATEGORIES_LOADABLE(UNIQUE_NAME) @interface FORCELOAD_##UNIQUE_NAME @end @implementation FORCELOAD_##UNIQUE_NAME @end
+#define MAKE_CATEGORIES_LOADABLE(UNIQUE_NAME) @interface FORCELOAD_##UNIQUE_NAME : NSObject @end @implementation FORCELOAD_##UNIQUE_NAME @end

--- a/Source/Shared/SYParser.h
+++ b/Source/Shared/SYParser.h
@@ -9,7 +9,6 @@
 #import <Foundation/Foundation.h>
 #import "SYFilter.h"
 
-
 @interface SYParser : NSObject {
     NSScanner *_scanner;
 

--- a/Source/Shared/SYParser.m
+++ b/Source/Shared/SYParser.m
@@ -8,7 +8,7 @@
 
 #import "SYParser.h"
 #import "SYParents.h"
-#import "SYPredicateFilter.h"
+#import "SYSelectorFilter.h"
 #import "SYClassFilter.h"
 #import "SYNthElementFilter.h"
 
@@ -278,7 +278,7 @@
         selectorDesc = [[[parsedSection params] componentsJoinedByString:@":"] stringByAppendingString:@":"];
     }
     
-    return [[[SYPredicateFilter alloc] initWithSelector:NSSelectorFromString(selectorDesc) 
+    return [[[SYSelectorFilter alloc] initWithSelector:NSSelectorFromString(selectorDesc) 
                                                    args:[parsedSection args]] autorelease];
 }
 

--- a/Source/Shared/SYParser.m
+++ b/Source/Shared/SYParser.m
@@ -12,6 +12,7 @@
 #import "SYClassFilter.h"
 #import "SYNthElementFilter.h"
 #import "SYPredicateFilter.h"
+#import "SYUIAElementFilter.h"
 
 @interface SYSectionParser : NSObject {
     NSScanner *_scanner;
@@ -294,8 +295,10 @@
         else if ([firstParam isEqualToString:@"descendant"]) {
             return [[[SYClassFilter alloc] initWithClass:[ShelleyView class] includeSelf:YES] autorelease];
         }
+        else if ([firstParam isEqualToString:@"uiaelement"]) {
+            return [[[SYUIAElementFilter alloc] init] autorelease];
+        }
     } else if ([[parsedSection args] count] == 1) {
-        
         if ([firstParam isEqualToString:@"view"]) {
             NSString *firstArg = [[parsedSection args] objectAtIndex:0];
             return [[[SYClassFilter alloc] initWithClass:(NSClassFromString(firstArg))] autorelease];
@@ -307,6 +310,10 @@
         else if ([firstParam isEqualToString:@"index"]) {
             NSNumber *firstArg = [[parsedSection args] objectAtIndex:0];
             return [[[SYNthElementFilter alloc] initWithIndex:[firstArg unsignedIntValue]] autorelease];
+        }
+        else if ([firstParam isEqualToString:@"uiaelement"]) {
+            NSString *firstArg = [[parsedSection args] objectAtIndex:0];
+            return [[[SYUIAElementFilter alloc] initWithTraitsFilter:firstArg] autorelease];
         }
     }
     

--- a/Source/Shared/SYParser.m
+++ b/Source/Shared/SYParser.m
@@ -12,7 +12,10 @@
 #import "SYClassFilter.h"
 #import "SYNthElementFilter.h"
 #import "SYPredicateFilter.h"
+
+#if TARGET_OS_IPHONE
 #import "SYUIAElementFilter.h"
+#endif
 
 @interface SYSectionParser : NSObject {
     NSScanner *_scanner;
@@ -295,9 +298,11 @@
         else if ([firstParam isEqualToString:@"descendant"]) {
             return [[[SYClassFilter alloc] initWithClass:[ShelleyView class] includeSelf:YES] autorelease];
         }
+#if TARGET_OS_IPHONE
         else if ([firstParam isEqualToString:@"uiaelement"]) {
             return [[[SYUIAElementFilter alloc] init] autorelease];
         }
+#endif
     } else if ([[parsedSection args] count] == 1) {
         if ([firstParam isEqualToString:@"view"]) {
             NSString *firstArg = [[parsedSection args] objectAtIndex:0];
@@ -311,10 +316,12 @@
             NSNumber *firstArg = [[parsedSection args] objectAtIndex:0];
             return [[[SYNthElementFilter alloc] initWithIndex:[firstArg unsignedIntValue]] autorelease];
         }
+#if TARGET_OS_IPHONE
         else if ([firstParam isEqualToString:@"uiaelement"]) {
             NSString *firstArg = [[parsedSection args] objectAtIndex:0];
             return [[[SYUIAElementFilter alloc] initWithTraitsFilter:firstArg] autorelease];
         }
+#endif
     }
     
     NSString *selectorDescriptor;

--- a/Source/Shared/Shelley.h
+++ b/Source/Shared/Shelley.h
@@ -11,7 +11,7 @@
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
 
-#define ShelleyView UIView
+#define ShelleyView NSObject
 
 #else
 

--- a/Source/iOS/UIView+ShelleyExtensions.m
+++ b/Source/iOS/UIView+ShelleyExtensions.m
@@ -7,6 +7,7 @@
 //
 
 #import "LoadableCategory.h"
+#import "Shelley.h"
 
 #import <QuartzCore/QuartzCore.h>
 
@@ -21,15 +22,55 @@ BOOL substringMatch(NSString *actualString, NSString *expectedSubstring){
     return actualString && ([actualString rangeOfString:expectedSubstring].location != NSNotFound);    
 }
 
-@implementation UIView (ShelleyExtensions)
+@implementation NSObject (SYAccessibilityIdentifier)
+
+- (NSString*)SY_accessibilityIdentifier {
+    NSString* accessibilityIdentifier = nil;
+    
+    if ([self respondsToSelector:@selector(accessibilityIdentifier)]) {
+        accessibilityIdentifier = [(id<UIAccessibilityIdentification>) self accessibilityIdentifier];
+    }
+    
+    return accessibilityIdentifier;
+}
+
+- (NSString*)SY_accessibilityLabel {
+    NSString* accessibilityLabel = nil;
+    
+    if ([self respondsToSelector:@selector(accessibilityLabel)]) {
+        accessibilityLabel = [self accessibilityLabel];
+    }
+    
+    return accessibilityLabel;
+}
 
 - (BOOL) marked:(NSString *)targetLabel{
-    return substringMatch([self accessibilityLabel], targetLabel);
+    if (substringMatch([self SY_accessibilityIdentifier], targetLabel)) {
+        return YES;
+    }
+    else if (substringMatch([self SY_accessibilityLabel], targetLabel)) {
+        return YES;
+    }
+    else {
+        return NO;
+    }
 }
 
 - (BOOL) markedExactly:(NSString *)targetLabel{
-    return [[self accessibilityLabel] isEqualToString:targetLabel];
+    if ([targetLabel isEqualToString:[self SY_accessibilityIdentifier]]) {
+        return YES;
+    }
+    else if ([targetLabel isEqualToString:[self SY_accessibilityLabel]]) {
+        return YES;
+    }
+    else {
+        return NO;
+    }
 }
+
+@end
+
+@implementation UIView (ShelleyExtensions)
 
 - (BOOL) isAnimating {
     return (self.layer.animationKeys.count > 0);

--- a/Unit Tests/SYParserTests.m
+++ b/Unit Tests/SYParserTests.m
@@ -9,7 +9,7 @@
 #import "SYParserTests.h"
 #import "SYParser.h"
 #import "SYParents.h"
-#import "SYPredicateFilter.h"
+#import "SYSelectorFilter.h"
 #import "SYClassFilter.h"
 #import "SYNthElementFilter.h"
 
@@ -49,11 +49,11 @@
     SYParser *parser = [[SYParser alloc] initWithSelectorString:@"noArgMethod"];
     
     id<SYFilter> filter = [parser nextFilter];
-    STAssertTrue([filter isKindOfClass:[SYPredicateFilter class]], nil);
+    STAssertTrue([filter isKindOfClass:[SYSelectorFilter class]], nil);
     
-    SYPredicateFilter *predicateFilter = (SYPredicateFilter *)filter;
-    STAssertEquals((SEL)[predicateFilter selector], @selector(noArgMethod), nil);
-    STAssertEquals([[predicateFilter args] count], (NSUInteger)0, nil );
+    SYSelectorFilter *selectorFilter = (SYSelectorFilter *)filter;
+    STAssertEquals([selectorFilter selector], @selector(noArgMethod), nil);
+    STAssertEquals([[selectorFilter args] count], (NSUInteger)0, nil );
 
 }
 
@@ -61,13 +61,13 @@
     SYParser *parser = [[SYParser alloc] initWithSelectorString:@"singleArg:123"];
     
     id<SYFilter> filter = [parser nextFilter];
-    STAssertTrue([filter isKindOfClass:[SYPredicateFilter class]], nil);
+    STAssertTrue([filter isKindOfClass:[SYSelectorFilter class]], nil);
     
-    SYPredicateFilter *predicateFilter = (SYPredicateFilter *)filter;
-    STAssertEquals((SEL)[predicateFilter selector], @selector(singleArg:), nil);
-    STAssertEquals([[predicateFilter args] count], (NSUInteger)1,nil );
+    SYSelectorFilter *selectorFilter = (SYSelectorFilter *)filter;
+    STAssertEquals([selectorFilter selector], @selector(singleArg:), nil);
+    STAssertEquals([[selectorFilter args] count], (NSUInteger)1,nil );
     
-    NSNumber *firstArg = [[predicateFilter args] objectAtIndex:0];
+    NSNumber *firstArg = [[selectorFilter args] objectAtIndex:0];
     STAssertTrue( [firstArg isEqualToNumber:[NSNumber numberWithInt:123]], nil);
 }
 
@@ -75,19 +75,19 @@
     SYParser *parser = [[SYParser alloc] initWithSelectorString:@"argOne:123argTwo:'foo'argThree:789"];
     
     id<SYFilter> filter = [parser nextFilter];
-    STAssertTrue([filter isKindOfClass:[SYPredicateFilter class]], nil);
+    STAssertTrue([filter isKindOfClass:[SYSelectorFilter class]], nil);
     
-    SYPredicateFilter *predicateFilter = (SYPredicateFilter *)filter;
-    STAssertEquals((SEL)[predicateFilter selector], @selector(argOne:argTwo:argThree:), nil);
-    STAssertEquals([[predicateFilter args] count], (NSUInteger)3,nil );
+    SYSelectorFilter *selectorFilter = (SYSelectorFilter *)filter;
+    STAssertEquals([selectorFilter selector], @selector(argOne:argTwo:argThree:), nil);
+    STAssertEquals([[selectorFilter args] count], (NSUInteger)3,nil );
     
-    NSNumber *firstArg = [[predicateFilter args] objectAtIndex:0];
+    NSNumber *firstArg = [[selectorFilter args] objectAtIndex:0];
     STAssertTrue( [firstArg isEqualToNumber:[NSNumber numberWithInt:123]], nil);
 
-    NSString *secondArg = [[predicateFilter args] objectAtIndex:1];
+    NSString *secondArg = [[selectorFilter args] objectAtIndex:1];
     STAssertTrue( [secondArg isEqualToString:@"foo"], nil);
     
-    NSNumber *thirdArg = [[predicateFilter args] objectAtIndex:2];
+    NSNumber *thirdArg = [[selectorFilter args] objectAtIndex:2];
     STAssertTrue( [thirdArg isEqualToNumber:[NSNumber numberWithInt:789]], nil);
 }
 
@@ -95,12 +95,12 @@
     SYParser *parser = [[SYParser alloc] initWithSelectorString:@"foo:'xyz'"];
     
     id<SYFilter> filter = [parser nextFilter];
-    STAssertTrue([filter isKindOfClass:[SYPredicateFilter class]], nil);
+    STAssertTrue([filter isKindOfClass:[SYSelectorFilter class]], nil);
     
-    SYPredicateFilter *predicateFilter = (SYPredicateFilter *)filter;
-    STAssertEquals((SEL)[predicateFilter selector], @selector(foo:), nil);
-    STAssertEquals([[predicateFilter args] count], (NSUInteger)1,nil );
-    STAssertTrue([[[predicateFilter args] objectAtIndex:0] isEqualToString:@"xyz"],nil );
+    SYSelectorFilter *selectorFilter = (SYSelectorFilter *)filter;
+    STAssertEquals([selectorFilter selector], @selector(foo:), nil);
+    STAssertEquals([[selectorFilter args] count], (NSUInteger)1,nil );
+    STAssertTrue([[[selectorFilter args] objectAtIndex:0] isEqualToString:@"xyz"],nil );
 }
 
 - (void) testParsesDoubleQuoteStringArguments {
@@ -108,10 +108,10 @@
     
     id<SYFilter> filter = [parser nextFilter];
     
-    SYPredicateFilter *predicateFilter = (SYPredicateFilter *)filter;
-    STAssertEquals((SEL)[predicateFilter selector], @selector(foo:), nil);
-    STAssertEquals([[predicateFilter args] count], (NSUInteger)1,nil );
-    STAssertTrue([[[predicateFilter args] objectAtIndex:0] isEqualToString:@"xyz"],nil );
+    SYSelectorFilter *selectorFilter = (SYSelectorFilter *)filter;
+    STAssertEquals([selectorFilter selector], @selector(foo:), nil);
+    STAssertEquals([[selectorFilter args] count], (NSUInteger)1,nil );
+    STAssertTrue([[[selectorFilter args] objectAtIndex:0] isEqualToString:@"xyz"],nil );
 }
 
 - (void) testParsesQuotedStringsContainingSpaces {
@@ -119,9 +119,9 @@
     
     id<SYFilter> filter = [parser nextFilter];
     
-    SYPredicateFilter *predicateFilter = (SYPredicateFilter *)filter;
-    STAssertEquals([[predicateFilter args] count], (NSUInteger)1,nil );
-    STAssertTrue([[[predicateFilter args] objectAtIndex:0] isEqualToString:@"string with spaces"],nil );
+    SYSelectorFilter *selectorFilter = (SYSelectorFilter *)filter;
+    STAssertEquals([[selectorFilter args] count], (NSUInteger)1,nil );
+    STAssertTrue([[[selectorFilter args] objectAtIndex:0] isEqualToString:@"string with spaces"],nil );
 
 }
 
@@ -199,7 +199,7 @@
 #endif
     
     filter = [parser nextFilter];
-    STAssertTrue([filter isKindOfClass:[SYPredicateFilter class]], nil);
+    STAssertTrue([filter isKindOfClass:[SYSelectorFilter class]], nil);
     
     filter = [parser nextFilter];
     STAssertNil(filter, nil);

--- a/Unit Tests/SYSelectorFilterTests.h
+++ b/Unit Tests/SYSelectorFilterTests.h
@@ -1,5 +1,5 @@
 //
-//  SYPredicateFilterTests.h
+//  SYSelectorFilterTests.h
 //  Shelley
 //
 //  Created by Pete Hodgson on 7/22/11.
@@ -12,7 +12,7 @@
 
 #import <SenTestingKit/SenTestingKit.h>
 
-@interface SYPredicateFilterTests : SenTestCase {
+@interface SYSelectorFilterTests : SenTestCase {
     
 }
 

--- a/Unit Tests/SYSelectorFilterTests.m
+++ b/Unit Tests/SYSelectorFilterTests.m
@@ -1,14 +1,14 @@
 //
-//  SYPredicateFilterTests.m
+//  SYSelectorFilterTests.m
 //  Shelley
 //
 //  Created by Pete Hodgson on 7/22/11.
 //  Copyright 2011 ThoughtWorks. All rights reserved.
 //
 
-#import "SYPredicateFilterTests.h"
+#import "SYSelectorFilterTests.h"
 
-#import "SYPredicateFilter.h"
+#import "SYSelectorFilter.h"
 
 @interface DummyView : ShelleyView
 {
@@ -37,11 +37,11 @@
 @end
 
 
-@implementation SYPredicateFilterTests
+@implementation SYSelectorFilterTests
 
 - (void) testGracefullyHandlesViewNotRespondingToSelector{
     ShelleyView *view = [[[ShelleyView alloc] init]autorelease];
-    SYPredicateFilter *filter = [[[SYPredicateFilter alloc] initWithSelector:@selector(notPresent) args:[NSArray array]] autorelease];
+    SYSelectorFilter *filter = [[[SYSelectorFilter alloc] initWithSelector:@selector(notPresent) args:[NSArray array]] autorelease];
     
     NSArray *filteredViews = [filter applyToView:view];
     STAssertNotNil(filteredViews, nil);
@@ -51,7 +51,7 @@
 - (void) testCallsPredicateMethodOnView{
     DummyView *view = [[[DummyView alloc] init]autorelease];
     
-    SYPredicateFilter *filter = [[[SYPredicateFilter alloc] initWithSelector:@selector(dummyMethod) args:[NSArray array]] autorelease];
+    SYSelectorFilter *filter = [[[SYSelectorFilter alloc] initWithSelector:@selector(dummyMethod) args:[NSArray array]] autorelease];
     
     STAssertFalse([view methodWasCalled],nil);
     [filter applyToView:view];
@@ -62,7 +62,7 @@
     DummyView *view = [[[DummyView alloc] init]autorelease];
     view.returnValue = NO;
     
-    SYPredicateFilter *filter = [[[SYPredicateFilter alloc] initWithSelector:@selector(dummyMethod) args:[NSArray array]] autorelease];
+    SYSelectorFilter *filter = [[[SYSelectorFilter alloc] initWithSelector:@selector(dummyMethod) args:[NSArray array]] autorelease];
     
     NSArray *filteredViews = [filter applyToView:view];
     STAssertNotNil(filteredViews, nil);
@@ -73,7 +73,7 @@
     DummyView *view = [[[DummyView alloc] init]autorelease];
     view.returnValue = YES;
     
-    SYPredicateFilter *filter = [[[SYPredicateFilter alloc] initWithSelector:@selector(dummyMethod) args:[NSArray array]] autorelease];
+    SYSelectorFilter *filter = [[[SYSelectorFilter alloc] initWithSelector:@selector(dummyMethod) args:[NSArray array]] autorelease];
     
     NSArray *filteredViews = [filter applyToView:view];
     STAssertNotNil(filteredViews, nil);


### PR DESCRIPTION
Some of the extensions I discussed here: https://groups.google.com/forum/#!searchin/frank-discuss/extensions/frank-discuss/MG3qmTLW9QI/T6fdIqu3Hx0J
### 1. Predicates

Syntax: `filter:"<nspredicate>"`
Examples:
`view filter:'tag=10'`
`view filter='text contains[cd] "something"'`
### 2. Accessibility (iOS only)

Syntax: `uiaelement:"traits"`
Examples:
`uiaelement first` - will return the `UIApplication` object
`uiaelement marked:'something'` - will return only accessibility elements marked by the given string
`view:'UITableViewCell' uiaelement` - will return accessibility elements inside all table cells
`uiaelement:'keyboard-key'` - will return all elements with trait `UIAccessibilityTraitKeyboardKey`
`uiaelement:'keyboard-key, button'` - will return all elements with traits `UIAccessibilityTraitKeyboardKey` and `UIAccessibilityTraitButton`
### 3. Accessibility identifier

`marked:` and `markedExactly:` now also check `accessibilityIdentifier`
### Note

Note that accessibility also requires an update to Frank to enable tapping accessibility elements.
Please review and test.
