### PR TITLE
Shelly engine now uses passed application wrapper for traversing its windows.

### DIFF
--- a/Shelley.xcodeproj/project.pbxproj
+++ b/Shelley.xcodeproj/project.pbxproj
@@ -87,12 +87,12 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		3009123716A599960023CC56 /* libShellyMac.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libShellyMac.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		3009123716A599960023CC56 /* libShelleyMac.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libShelleyMac.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		3009123816A599960023CC56 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
 		3009123B16A599960023CC56 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
 		3009123C16A599960023CC56 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		3009123D16A599960023CC56 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
-		3009124916A599960023CC56 /* ShellyMacTests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ShellyMacTests.octest; sourceTree = BUILT_PRODUCTS_DIR; };
+		3009124916A599960023CC56 /* ShelleyMacTests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ShelleyMacTests.octest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3009124A16A599960023CC56 /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
 		30313F7816AB109B00DC6D3F /* ShelleyMacTests-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ShelleyMacTests-Prefix.pch"; sourceTree = "<group>"; };
 		30313F7A16AB171E00DC6D3F /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
@@ -280,8 +280,8 @@
 			children = (
 				D6E8FF3213D3DC9200D24F43 /* libShelley.a */,
 				D6CF39AC13D3E481000C7901 /* Unit Tests.octest */,
-				3009123716A599960023CC56 /* libShellyMac.a */,
-				3009124916A599960023CC56 /* ShellyMacTests.octest */,
+				3009123716A599960023CC56 /* libShelleyMac.a */,
+				3009124916A599960023CC56 /* ShelleyMacTests.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -365,7 +365,7 @@
 			);
 			name = ShelleyMac;
 			productName = ShellyMac;
-			productReference = 3009123716A599960023CC56 /* libShellyMac.a */;
+			productReference = 3009123716A599960023CC56 /* libShelleyMac.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		3009124816A599960023CC56 /* ShelleyMacTests */ = {
@@ -384,7 +384,7 @@
 			);
 			name = ShelleyMacTests;
 			productName = ShellyMacTests;
-			productReference = 3009124916A599960023CC56 /* ShellyMacTests.octest */;
+			productReference = 3009124916A599960023CC56 /* ShelleyMacTests.octest */;
 			productType = "com.apple.product-type.bundle";
 		};
 		D6CF39AB13D3E481000C7901 /* Unit Tests */ = {
@@ -789,6 +789,7 @@
 				GCC_PREFIX_HEADER = "Shelley/Shelley-Prefix.pch";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				USER_HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/../../src";
 			};
 			name = Debug;
 		};
@@ -801,6 +802,7 @@
 				GCC_PREFIX_HEADER = "Shelley/Shelley-Prefix.pch";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				USER_HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/../../src";
 			};
 			name = Release;
 		};

--- a/Shelley/SYFrankSelectorEngine.m
+++ b/Shelley/SYFrankSelectorEngine.m
@@ -18,6 +18,8 @@ static NSString *const registeredName = @"shelley_compat";
 
 @implementation SYFrankSelectorEngine
 
+@synthesize application;
+
 +(void)load{
     SYFrankSelectorEngine *registeredInstance = [[self alloc]init];
     [SelectorEngineRegistry registerSelectorEngine:registeredInstance WithName:registeredName];
@@ -29,12 +31,8 @@ static NSString *const registeredName = @"shelley_compat";
     NSLog( @"Using %s to select views with selector: %@", VERSIONED_NAME, selector );
     
     Shelley *shelley = [Shelley withSelectorString:selector];
-    
-#if TARGET_OS_IPHONE
-    return [shelley selectFromViews:[[UIApplication sharedApplication] windows]];
-#else
-    return [shelley selectFromViews: [NSArray arrayWithObject: [NSApplication sharedApplication]]];
-#endif
+
+    return [shelley selectFromViews:[self.application windows]];
 }
 
 @end

--- a/Shelley/SYFrankSelectorEngine.m
+++ b/Shelley/SYFrankSelectorEngine.m
@@ -29,7 +29,12 @@ static NSString *const registeredName = @"shelley_compat";
 
 - (NSArray *) selectViewsWithSelector:(NSString *)selector {
     NSLog( @"Using %s to select views with selector: %@", VERSIONED_NAME, selector );
-    
+
+    if (!self.application) {
+        [NSException raise:@"unknown application"
+                    format:@"no application wrapper set for %s engine that could provide array of windows to select views with selector \"%@\"", VERSIONED_NAME, selector];
+    }
+
     Shelley *shelley = [Shelley withSelectorString:selector];
 
     return [shelley selectFromViews:[self.application windows]];

--- a/Shelley/SelectorEngineRegistry.h
+++ b/Shelley/SelectorEngineRegistry.h
@@ -7,15 +7,9 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "SelectorEngineProtocols.h"
 
-@protocol SelectorEngine <NSObject>
-
-- (NSArray *) selectViewsWithSelector:(NSString *)selector;
-
-@end
-
-@interface SelectorEngineRegistry : NSObject{
-}
+@interface SelectorEngineRegistry : NSObject
 
 + (void) registerSelectorEngine:(id<SelectorEngine>)engine WithName:(NSString *)name;
 + (NSArray *) selectViewsWithEngineNamed:(NSString *)engineName usingSelector:(NSString *)selector;


### PR DESCRIPTION
Make SelectorEngineRegistry header use the new shared protocols header.

Please see also accompanying pull request on branch "ios7-alerts" of https://github.com/oradyvan/Frank
